### PR TITLE
Add authentication tests

### DIFF
--- a/src/__tests__/hooks/useAuth.test.ts
+++ b/src/__tests__/hooks/useAuth.test.ts
@@ -6,7 +6,6 @@ import { signIn } from 'next-auth/react'
 
 jest.mock('next-auth/react', () => ({
   signIn: jest.fn(),
-  signOut: jest.fn(),
   useSession: jest.fn(() => ({ data: null, status: 'unauthenticated' })),
 }))
 

--- a/src/__tests__/hooks/useAuth.test.ts
+++ b/src/__tests__/hooks/useAuth.test.ts
@@ -54,10 +54,10 @@ describe('useAuthWithRouter login', () => {
     const { result } = renderHook(() => useAuthWithRouter())
 
     await act(async () => {
-      await result.current.login({ email: 'x@x.com', password: 'bad' })
+      await expect(
+        result.current.login({ email: 'x@x.com', password: 'bad' })
+      ).rejects.toThrow('Invalid credentials')
     })
-
-    await expect(result.current.login({ email: 'x@x.com', password: 'bad' })).rejects.toThrow('Invalid credentials')
     expect(useAuthStore.getState().isLoggingIn).toBe(false)
     expect(useAuthStore.getState().authModalOpen).toBe(true)
   })
@@ -90,11 +90,17 @@ describe('useAuthWithRouter register', () => {
 
     const { result } = renderHook(() => useAuthWithRouter())
 
-    await expect(
-      act(async () => {
-        await result.current.register({ username: 'test', email: 't@e.com', password: 'Password1', confirmPassword: 'Password1', role: 'user' })
-      })
-    ).rejects.toThrow('fail')
+    await act(async () => {
+      await expect(
+        result.current.register({
+          username: 'test',
+          email: 't@e.com',
+          password: 'Password1',
+          confirmPassword: 'Password1',
+          role: 'user',
+        })
+      ).rejects.toThrow('fail')
+    })
 
     expect(useAuthStore.getState().isRegistering).toBe(false)
     expect(useAuthStore.getState().authModalOpen).toBe(true)

--- a/src/__tests__/hooks/useAuth.test.ts
+++ b/src/__tests__/hooks/useAuth.test.ts
@@ -53,12 +53,11 @@ describe('useAuthWithRouter login', () => {
 
     const { result } = renderHook(() => useAuthWithRouter())
 
-    await expect(
-      act(async () => {
-        await result.current.login({ email: 'x@x.com', password: 'bad' })
-      })
-    ).rejects.toThrow('Invalid credentials')
+    await act(async () => {
+      await result.current.login({ email: 'x@x.com', password: 'bad' })
+    })
 
+    await expect(result.current.login({ email: 'x@x.com', password: 'bad' })).rejects.toThrow('Invalid credentials')
     expect(useAuthStore.getState().isLoggingIn).toBe(false)
     expect(useAuthStore.getState().authModalOpen).toBe(true)
   })

--- a/src/__tests__/hooks/useAuth.test.ts
+++ b/src/__tests__/hooks/useAuth.test.ts
@@ -1,0 +1,104 @@
+import { renderHook, act } from '@testing-library/react'
+import { useAuthWithRouter } from '@/hooks/useAuth'
+import { useAuthStore } from '@/lib/store/auth'
+import * as authApi from '@/lib/api/auth'
+import { signIn } from 'next-auth/react'
+
+jest.mock('next-auth/react', () => ({
+  signIn: jest.fn(),
+  signOut: jest.fn(),
+  useSession: jest.fn(() => ({ data: null, status: 'unauthenticated' })),
+}))
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: jest.fn() }),
+}))
+
+jest.mock('react-hot-toast', () => ({
+  __esModule: true,
+  default: { success: jest.fn(), error: jest.fn() },
+}))
+
+jest.mock('@/lib/api/auth', () => ({
+  register: jest.fn(),
+}))
+
+describe('useAuthWithRouter login', () => {
+  beforeEach(() => {
+    const state = useAuthStore.getState()
+    state.setIsLoggingIn(false)
+    state.setAuthModalOpen(true)
+    jest.clearAllMocks()
+  })
+
+  it('logs in successfully', async () => {
+    ;(signIn as jest.Mock).mockResolvedValue({ ok: true })
+
+    const { result } = renderHook(() => useAuthWithRouter())
+
+    await act(async () => {
+      await result.current.login({ email: 'test@example.com', password: 'Password1' })
+    })
+
+    expect(signIn).toHaveBeenCalledWith('credentials', {
+      email: 'test@example.com',
+      password: 'Password1',
+      redirect: false,
+    })
+    expect(useAuthStore.getState().isLoggingIn).toBe(false)
+    expect(useAuthStore.getState().authModalOpen).toBe(false)
+  })
+
+  it('handles login error', async () => {
+    ;(signIn as jest.Mock).mockResolvedValue({ error: 'Invalid credentials' })
+
+    const { result } = renderHook(() => useAuthWithRouter())
+
+    await expect(
+      act(async () => {
+        await result.current.login({ email: 'x@x.com', password: 'bad' })
+      })
+    ).rejects.toThrow('Invalid credentials')
+
+    expect(useAuthStore.getState().isLoggingIn).toBe(false)
+    expect(useAuthStore.getState().authModalOpen).toBe(true)
+  })
+})
+
+describe('useAuthWithRouter register', () => {
+  beforeEach(() => {
+    const state = useAuthStore.getState()
+    state.setIsRegistering(false)
+    state.setAuthModalOpen(true)
+    jest.clearAllMocks()
+  })
+
+  it('registers successfully', async () => {
+    ;(authApi.register as jest.Mock).mockResolvedValue({ _id: '1', username: 'test', email: 't@e.com', role: 'user', createdAt: '', isAdmin: false })
+
+    const { result } = renderHook(() => useAuthWithRouter())
+
+    await act(async () => {
+      await result.current.register({ username: 'test', email: 't@e.com', password: 'Password1', confirmPassword: 'Password1', role: 'user' })
+    })
+
+    expect(authApi.register).toHaveBeenCalled()
+    expect(useAuthStore.getState().isRegistering).toBe(false)
+    expect(useAuthStore.getState().authModalOpen).toBe(false)
+  })
+
+  it('handles register error', async () => {
+    ;(authApi.register as jest.Mock).mockRejectedValue(new Error('fail'))
+
+    const { result } = renderHook(() => useAuthWithRouter())
+
+    await expect(
+      act(async () => {
+        await result.current.register({ username: 'test', email: 't@e.com', password: 'Password1', confirmPassword: 'Password1', role: 'user' })
+      })
+    ).rejects.toThrow('fail')
+
+    expect(useAuthStore.getState().isRegistering).toBe(false)
+    expect(useAuthStore.getState().authModalOpen).toBe(true)
+  })
+})

--- a/src/__tests__/lib/authValidations.test.ts
+++ b/src/__tests__/lib/authValidations.test.ts
@@ -30,7 +30,7 @@ describe('registerSchema', () => {
   }
 
   it('accepts valid data', () => {
-    expect(registerSchema.parse(base)).toMatchObject(base)
+    expect(registerSchema.parse(base)).toEqual(base)
   })
 
   it('requires matching passwords', () => {

--- a/src/__tests__/lib/authValidations.test.ts
+++ b/src/__tests__/lib/authValidations.test.ts
@@ -1,0 +1,47 @@
+import { loginSchema, registerSchema } from '@/lib/validations/auth'
+
+describe('loginSchema', () => {
+  const validData = { email: 'test@example.com', password: 'Password1' }
+
+  it('accepts valid data', () => {
+    expect(loginSchema.parse(validData)).toEqual(validData)
+  })
+
+  it('rejects invalid email', () => {
+    expect(() =>
+      loginSchema.parse({ ...validData, email: 'invalid' })
+    ).toThrow()
+  })
+
+  it('rejects short password', () => {
+    expect(() =>
+      loginSchema.parse({ ...validData, password: 'short' })
+    ).toThrow()
+  })
+})
+
+describe('registerSchema', () => {
+  const base = {
+    username: 'tester',
+    email: 'test@example.com',
+    password: 'Password1',
+    confirmPassword: 'Password1',
+    role: 'user' as const,
+  }
+
+  it('accepts valid data', () => {
+    expect(registerSchema.parse(base)).toMatchObject(base)
+  })
+
+  it('requires matching passwords', () => {
+    expect(() =>
+      registerSchema.parse({ ...base, confirmPassword: 'Other123' })
+    ).toThrow()
+  })
+
+  it('requires strong password', () => {
+    expect(() =>
+      registerSchema.parse({ ...base, password: 'weak', confirmPassword: 'weak' })
+    ).toThrow()
+  })
+})


### PR DESCRIPTION
## Summary
- add validation tests for login and register forms
- add hook tests for login and register actions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854d325608c832a90d067db3351a11f