### PR TITLE
fix(profile): remove debug info block (FE-16)

### DIFF
--- a/src/components/auth/profile-form.tsx
+++ b/src/components/auth/profile-form.tsx
@@ -21,7 +21,7 @@ export function ProfileForm() {
   const [user, setUser] = useState<User | null>(null);
   const [isLoadingProfile, setIsLoadingProfile] = useState(true);
   const [originalValues, setOriginalValues] = useState<UpdateProfileFormData | null>(null);
-  const { user: sessionUser, isAuthenticated, status } = useAuthWithRouter();
+  const { isAuthenticated } = useAuthWithRouter();
 
   const {
     register,
@@ -150,22 +150,6 @@ export function ProfileForm() {
         </div>
       </CardHeader>
       <CardContent>
-        {/* Debug info */}
-        <div className="mb-4 rounded bg-gray-100 p-3 text-sm">
-          <p>
-            <strong>Status:</strong> {status}
-          </p>
-          <p>
-            <strong>Authenticated:</strong> {isAuthenticated ? "Yes" : "No"}
-          </p>
-          <p>
-            <strong>Has Session:</strong> {isAuthenticated ? "Yes" : "No"}
-          </p>
-          <p>
-            <strong>User ID:</strong> {sessionUser?.id || "None"}
-          </p>
-        </div>
-
         <form onSubmit={handleSubmit(handleUpdateProfile)} className="space-y-6" noValidate>
           {/* Profile Picture */}
           <div className="flex items-center space-x-4">


### PR DESCRIPTION
## Summary
Remove the debug info block from `profile-form.tsx` that was exposing user ID, session status, and authentication state directly in the UI without a `NODE_ENV` guard.

1 file changed, 1 insertion(+), 17 deletions(-)

## Audit reference
FE-16 (Critical) — Information leak in production. Any visitor to `/profile` could see the authenticated user's internal ID and session details.

## Test plan
- [x] Debug block fully removed from JSX
- [x] Orphan destructures cleaned (status, sessionUser removed — only isAuthenticated used elsewhere)
- [x] tsc --noEmit clean
- [x] Verified no other "always-visible debug" blocks in project