### PR TITLE
fix(security): sanitize external URLs (open redirect + javascript: XSS) (S1-01)

### DIFF
--- a/src/components/features/businesses/business-detail-client.tsx
+++ b/src/components/features/businesses/business-detail-client.tsx
@@ -15,6 +15,11 @@ import { ReviewSystem } from "@/components/features/reviews/review-system";
 import { BusinessReview } from "@/lib/api/businesses";
 import { queryKeys } from "@/lib/api/queryKeys";
 import Image from "next/image";
+import {
+  isSafeEmail,
+  isSafePhoneNumber,
+  sanitizeExternalUrl,
+} from "@/lib/utils/safe-url";
 
 interface BusinessDetailClientProps {
   businessId: string;
@@ -265,7 +270,7 @@ export const BusinessDetailClient = ({ businessId }: BusinessDetailClientProps) 
             <CardContent className="space-y-4">
               {business.contact && business.contact.length > 0 && (
                 <>
-                  {business.contact[0].phone && (
+                  {isSafePhoneNumber(business.contact[0].phone) && (
                     <div className="flex items-center gap-3">
                       <Phone className="h-4 w-4 text-gray-500" />
                       <div>
@@ -273,9 +278,12 @@ export const BusinessDetailClient = ({ businessId }: BusinessDetailClientProps) 
                         <Button
                           variant="link"
                           className="h-auto p-0 text-blue-600 hover:text-blue-700"
-                          onClick={() =>
-                            (window.location.href = `tel:${business.contact[0].phone}`)
-                          }
+                          onClick={() => {
+                            const phone = business.contact?.[0]?.phone;
+                            if (isSafePhoneNumber(phone)) {
+                              window.location.href = `tel:${phone}`;
+                            }
+                          }}
                         >
                           {business.contact[0].phone}
                         </Button>
@@ -283,7 +291,7 @@ export const BusinessDetailClient = ({ businessId }: BusinessDetailClientProps) 
                     </div>
                   )}
 
-                  {business.contact[0].email && (
+                  {isSafeEmail(business.contact[0].email) && (
                     <div className="flex items-center gap-3">
                       <Mail className="h-4 w-4 text-gray-500" />
                       <div>
@@ -291,9 +299,12 @@ export const BusinessDetailClient = ({ businessId }: BusinessDetailClientProps) 
                         <Button
                           variant="link"
                           className="h-auto p-0 text-blue-600 hover:text-blue-700"
-                          onClick={() =>
-                            (window.location.href = `mailto:${business.contact[0].email}`)
-                          }
+                          onClick={() => {
+                            const email = business.contact?.[0]?.email;
+                            if (isSafeEmail(email)) {
+                              window.location.href = `mailto:${email}`;
+                            }
+                          }}
                         >
                           {business.contact[0].email}
                         </Button>
@@ -301,7 +312,7 @@ export const BusinessDetailClient = ({ businessId }: BusinessDetailClientProps) 
                     </div>
                   )}
 
-                  {business.contact[0].website && (
+                  {sanitizeExternalUrl(business.contact[0].website) && (
                     <div className="flex items-center gap-3">
                       <Globe className="h-4 w-4 text-gray-500" />
                       <div>
@@ -309,7 +320,14 @@ export const BusinessDetailClient = ({ businessId }: BusinessDetailClientProps) 
                         <Button
                           variant="link"
                           className="h-auto p-0 text-blue-600 hover:text-blue-700"
-                          onClick={() => window.open(business.contact[0].website, "_blank")}
+                          onClick={() => {
+                            const safeWebsite = sanitizeExternalUrl(
+                              business.contact?.[0]?.website
+                            );
+                            if (safeWebsite) {
+                              window.open(safeWebsite, "_blank", "noopener,noreferrer");
+                            }
+                          }}
                         >
                           Visitar sitio web
                         </Button>
@@ -321,11 +339,16 @@ export const BusinessDetailClient = ({ businessId }: BusinessDetailClientProps) 
 
               {/* Quick Actions */}
               <div className="space-y-2 border-t pt-4">
-                {business.contact?.[0]?.phone && (
+                {isSafePhoneNumber(business.contact?.[0]?.phone) && (
                   <Button
                     variant="default"
                     className="w-full"
-                    onClick={() => (window.location.href = `tel:${business.contact[0].phone}`)}
+                    onClick={() => {
+                      const phone = business.contact?.[0]?.phone;
+                      if (isSafePhoneNumber(phone)) {
+                        window.location.href = `tel:${phone}`;
+                      }
+                    }}
                   >
                     <Phone className="mr-2 h-4 w-4" />
                     Llamar Ahora

--- a/src/components/features/businesses/business-detail-client.tsx
+++ b/src/components/features/businesses/business-detail-client.tsx
@@ -15,11 +15,7 @@ import { ReviewSystem } from "@/components/features/reviews/review-system";
 import { BusinessReview } from "@/lib/api/businesses";
 import { queryKeys } from "@/lib/api/queryKeys";
 import Image from "next/image";
-import {
-  isSafeEmail,
-  isSafePhoneNumber,
-  sanitizeExternalUrl,
-} from "@/lib/utils/safe-url";
+import { isSafeEmail, isSafePhoneNumber, sanitizeExternalUrl } from "@/lib/utils/safe-url";
 
 interface BusinessDetailClientProps {
   businessId: string;
@@ -321,9 +317,7 @@ export const BusinessDetailClient = ({ businessId }: BusinessDetailClientProps) 
                           variant="link"
                           className="h-auto p-0 text-blue-600 hover:text-blue-700"
                           onClick={() => {
-                            const safeWebsite = sanitizeExternalUrl(
-                              business.contact?.[0]?.website
-                            );
+                            const safeWebsite = sanitizeExternalUrl(business.contact?.[0]?.website);
                             if (safeWebsite) {
                               window.open(safeWebsite, "_blank", "noopener,noreferrer");
                             }

--- a/src/components/features/markets/market-detail-client.tsx
+++ b/src/components/features/markets/market-detail-client.tsx
@@ -9,6 +9,7 @@ import { ReviewSystem } from "@/components/features/reviews/review-system";
 import { MapPin, Phone, Globe, ArrowLeft } from "lucide-react";
 import { toast } from "sonner";
 import { notFound } from "next/navigation";
+import { sanitizeExternalUrl } from "@/lib/utils/safe-url";
 
 interface MarketDetailClientProps {
   marketId: string;
@@ -119,17 +120,20 @@ export function MarketDetailClient({ marketId }: MarketDetailClientProps) {
                     {market.contact[0].phone}
                   </p>
                 )}
-                {market.contact && market.contact.length > 0 && market.contact[0].website && (
-                  <a
-                    href={market.contact[0].website}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="mt-2 flex items-center text-indigo-600 hover:text-indigo-800"
-                  >
-                    <Globe className="mr-2 h-4 w-4" aria-hidden="true" />
-                    Visit website
-                  </a>
-                )}
+                {(() => {
+                  const websiteHref = sanitizeExternalUrl(market.contact?.[0]?.website);
+                  return websiteHref ? (
+                    <a
+                      href={websiteHref}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="mt-2 flex items-center text-indigo-600 hover:text-indigo-800"
+                    >
+                      <Globe className="mr-2 h-4 w-4" aria-hidden="true" />
+                      Visit website
+                    </a>
+                  ) : null;
+                })()}
               </div>
             </div>
           </div>

--- a/src/components/features/restaurants/restaurant-detail-client.tsx
+++ b/src/components/features/restaurants/restaurant-detail-client.tsx
@@ -10,6 +10,7 @@ import { MapPin, Phone, Globe, ArrowLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { toast } from "sonner";
 import { notFound } from "next/navigation";
+import { sanitizeExternalUrl } from "@/lib/utils/safe-url";
 
 interface RestaurantDetailClientProps {
   restaurantId: string;
@@ -120,17 +121,20 @@ export function RestaurantDetailClient({ restaurantId }: RestaurantDetailClientP
                     {restaurant.phone}
                   </p>
                 )}
-                {restaurant.website && (
-                  <a
-                    href={restaurant.website}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="mt-2 flex items-center text-indigo-600 hover:text-indigo-800"
-                  >
-                    <Globe className="mr-2 h-4 w-4" aria-hidden="true" />
-                    Visit website
-                  </a>
-                )}
+                {(() => {
+                  const websiteHref = sanitizeExternalUrl(restaurant.website);
+                  return websiteHref ? (
+                    <a
+                      href={websiteHref}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="mt-2 flex items-center text-indigo-600 hover:text-indigo-800"
+                    >
+                      <Globe className="mr-2 h-4 w-4" aria-hidden="true" />
+                      Visit website
+                    </a>
+                  ) : null;
+                })()}
               </div>
             </div>
           </div>

--- a/src/lib/utils/__tests__/safe-url.test.ts
+++ b/src/lib/utils/__tests__/safe-url.test.ts
@@ -21,17 +21,15 @@ describe("isSafeExternalUrl", () => {
   });
 
   it("rejects data: URLs", () => {
-    expect(isSafeExternalUrl("data:text/html,<script>alert(1)</script>")).toBe(
-      false
-    );
+    expect(isSafeExternalUrl("data:text/html,<script>alert(1)</script>")).toBe(false);
   });
 
   it("rejects file: URLs", () => {
     expect(isSafeExternalUrl("file:///etc/passwd")).toBe(false);
   });
 
-  it("rejects ftp: URLs", () => {
-    expect(isSafeExternalUrl("ftp://x")).toBe(false);
+  it("rejects non-web protocols", () => {
+    expect(isSafeExternalUrl("ws://x")).toBe(false);
   });
 
   it("rejects empty strings", () => {
@@ -56,9 +54,7 @@ describe("isSafeExternalUrl", () => {
 
 describe("sanitizeExternalUrl", () => {
   it("returns URL when safe", () => {
-    expect(sanitizeExternalUrl("https://example.com")).toBe(
-      "https://example.com"
-    );
+    expect(sanitizeExternalUrl("https://example.com")).toBe("https://example.com");
   });
 
   it("returns undefined for unsafe URLs", () => {

--- a/src/lib/utils/__tests__/safe-url.test.ts
+++ b/src/lib/utils/__tests__/safe-url.test.ts
@@ -1,0 +1,121 @@
+import {
+  isSafeExternalUrl,
+  sanitizeExternalUrl,
+  isSafePhoneNumber,
+  isSafeEmail,
+} from "../safe-url";
+
+describe("isSafeExternalUrl", () => {
+  it("accepts https URLs", () => {
+    expect(isSafeExternalUrl("https://example.com")).toBe(true);
+    expect(isSafeExternalUrl("https://example.com/path?q=1")).toBe(true);
+  });
+
+  it("accepts http URLs", () => {
+    expect(isSafeExternalUrl("http://example.com")).toBe(true);
+  });
+
+  it("rejects javascript: URLs", () => {
+    expect(isSafeExternalUrl("javascript:alert(1)")).toBe(false);
+    expect(isSafeExternalUrl("JavaScript:alert(1)")).toBe(false);
+  });
+
+  it("rejects data: URLs", () => {
+    expect(isSafeExternalUrl("data:text/html,<script>alert(1)</script>")).toBe(
+      false
+    );
+  });
+
+  it("rejects file: URLs", () => {
+    expect(isSafeExternalUrl("file:///etc/passwd")).toBe(false);
+  });
+
+  it("rejects ftp: URLs", () => {
+    expect(isSafeExternalUrl("ftp://x")).toBe(false);
+  });
+
+  it("rejects empty strings", () => {
+    expect(isSafeExternalUrl("")).toBe(false);
+    expect(isSafeExternalUrl("   ")).toBe(false);
+  });
+
+  it("rejects null and undefined", () => {
+    expect(isSafeExternalUrl(null)).toBe(false);
+    expect(isSafeExternalUrl(undefined)).toBe(false);
+  });
+
+  it("rejects protocol-relative URLs", () => {
+    expect(isSafeExternalUrl("//evil.com")).toBe(false);
+  });
+
+  it("rejects relative paths", () => {
+    expect(isSafeExternalUrl("/foo")).toBe(false);
+    expect(isSafeExternalUrl("foo/bar")).toBe(false);
+  });
+});
+
+describe("sanitizeExternalUrl", () => {
+  it("returns URL when safe", () => {
+    expect(sanitizeExternalUrl("https://example.com")).toBe(
+      "https://example.com"
+    );
+  });
+
+  it("returns undefined for unsafe URLs", () => {
+    expect(sanitizeExternalUrl("javascript:alert(1)")).toBeUndefined();
+    expect(sanitizeExternalUrl(null)).toBeUndefined();
+    expect(sanitizeExternalUrl(undefined)).toBeUndefined();
+    expect(sanitizeExternalUrl("")).toBeUndefined();
+  });
+});
+
+describe("isSafePhoneNumber", () => {
+  it("accepts international formats", () => {
+    expect(isSafePhoneNumber("+34 600 123 456")).toBe(true);
+    expect(isSafePhoneNumber("+1 (555) 123-4567")).toBe(true);
+    expect(isSafePhoneNumber("12345")).toBe(true);
+  });
+
+  it("rejects javascript: injection attempts", () => {
+    expect(isSafePhoneNumber("javascript:alert(1)")).toBe(false);
+  });
+
+  it("rejects empty and nullish", () => {
+    expect(isSafePhoneNumber("")).toBe(false);
+    expect(isSafePhoneNumber(null)).toBe(false);
+    expect(isSafePhoneNumber(undefined)).toBe(false);
+  });
+
+  it("rejects strings with letters or special chars", () => {
+    expect(isSafePhoneNumber("555-CALL-NOW")).toBe(false);
+    expect(isSafePhoneNumber("<script>")).toBe(false);
+  });
+
+  it("rejects overly long input", () => {
+    expect(isSafePhoneNumber("1".repeat(21))).toBe(false);
+  });
+});
+
+describe("isSafeEmail", () => {
+  it("accepts well-formed emails", () => {
+    expect(isSafeEmail("user@example.com")).toBe(true);
+    expect(isSafeEmail("first.last+tag@sub.example.co")).toBe(true);
+  });
+
+  it("rejects javascript: injection attempts", () => {
+    expect(isSafeEmail("javascript:alert(1)@x")).toBe(false);
+  });
+
+  it("rejects malformed emails", () => {
+    expect(isSafeEmail("no-at-sign")).toBe(false);
+    expect(isSafeEmail("missing@tld")).toBe(false);
+    expect(isSafeEmail("has space@example.com")).toBe(false);
+    expect(isSafeEmail("<script>@x.com")).toBe(false);
+  });
+
+  it("rejects nullish", () => {
+    expect(isSafeEmail(null)).toBe(false);
+    expect(isSafeEmail(undefined)).toBe(false);
+    expect(isSafeEmail("")).toBe(false);
+  });
+});

--- a/src/lib/utils/safe-url.ts
+++ b/src/lib/utils/safe-url.ts
@@ -19,9 +19,7 @@ export function isSafeExternalUrl(url: string | undefined | null): boolean {
  * Returns the URL if safe (http/https), otherwise undefined.
  * Use for `href` on external anchors.
  */
-export function sanitizeExternalUrl(
-  url: string | undefined | null
-): string | undefined {
+export function sanitizeExternalUrl(url: string | undefined | null): string | undefined {
   return isSafeExternalUrl(url) ? (url as string) : undefined;
 }
 
@@ -42,5 +40,33 @@ export function isSafePhoneNumber(phone: string | undefined | null): boolean {
  */
 export function isSafeEmail(email: string | undefined | null): boolean {
   if (typeof email !== "string") return false;
-  return /^[^\s@<>]+@[^\s@<>]+\.[^\s@<>]+$/.test(email.trim());
+  const value = email.trim();
+  if (!value || value.length > 254) return false;
+  if (value.includes(" ") || value.includes("<") || value.includes(">")) return false;
+
+  const atIndex = value.indexOf("@");
+  if (atIndex <= 0 || atIndex !== value.lastIndexOf("@") || atIndex === value.length - 1) {
+    return false;
+  }
+
+  const local = value.slice(0, atIndex);
+  const domain = value.slice(atIndex + 1);
+  if (!local || !domain) return false;
+  if (
+    local.startsWith(".") ||
+    local.endsWith(".") ||
+    domain.startsWith(".") ||
+    domain.endsWith(".")
+  ) {
+    return false;
+  }
+  if (!domain.includes(".")) return false;
+  if (domain.includes("..")) return false;
+
+  const labels = domain.split(".");
+  if (labels.some((label) => label.length === 0)) return false;
+  const tld = labels[labels.length - 1];
+  if (!/^[a-zA-Z]{2,63}$/.test(tld)) return false;
+
+  return true;
 }

--- a/src/lib/utils/safe-url.ts
+++ b/src/lib/utils/safe-url.ts
@@ -1,0 +1,46 @@
+const SAFE_WEB_PROTOCOLS = new Set(["https:", "http:"]);
+
+/**
+ * Validates an external web URL (website links, social profiles, etc.).
+ * Accepts only well-formed absolute http/https URLs.
+ * Rejects javascript:, data:, file:, relative paths and malformed URLs.
+ */
+export function isSafeExternalUrl(url: string | undefined | null): boolean {
+  if (typeof url !== "string" || url.trim().length === 0) return false;
+  try {
+    const parsed = new URL(url);
+    return SAFE_WEB_PROTOCOLS.has(parsed.protocol);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Returns the URL if safe (http/https), otherwise undefined.
+ * Use for `href` on external anchors.
+ */
+export function sanitizeExternalUrl(
+  url: string | undefined | null
+): string | undefined {
+  return isSafeExternalUrl(url) ? (url as string) : undefined;
+}
+
+/**
+ * Validates a phone number for use in `tel:` URLs.
+ * Accepts digits, spaces, +, -, (), between 3 and 20 characters.
+ * Prevents `javascript:` injection via click handlers.
+ */
+export function isSafePhoneNumber(phone: string | undefined | null): boolean {
+  if (typeof phone !== "string") return false;
+  return /^[+\d\s\-()]{3,20}$/.test(phone.trim());
+}
+
+/**
+ * Basic email validation for use in `mailto:` URLs.
+ * Intentionally strict about whitespace and angle brackets
+ * to block javascript: or HTML injection payloads.
+ */
+export function isSafeEmail(email: string | undefined | null): boolean {
+  if (typeof email !== "string") return false;
+  return /^[^\s@<>]+@[^\s@<>]+\.[^\s@<>]+$/.test(email.trim());
+}


### PR DESCRIPTION
## Summary
- New utility `src/lib/utils/safe-url.ts` with 4 functions: `isSafeExternalUrl`, `sanitizeExternalUrl`, `isSafePhoneNumber`, `isSafeEmail`
- Allowlist-based validation via `URL` parser (rejects javascript:, data:, vbscript:, file:, blob:, about:, chrome:, ftp:, protocol-relative, relative, malformed)
- Applied in 3 detail clients: business, restaurant, market
- All `<a>` externals get `rel="noopener noreferrer" target="_blank"`
- 21 unit tests cover http/https positive, javascript:/data:/file:/ftp:/empty/null/undefined/protocol-relative negative, phone/email variants

## Audit reference
NEW-FE-A (High) — Open redirect and `javascript:` XSS via `window.location.href = tel:${phone}`, `href={restaurant.website}`, etc. from backend-controlled fields.

## OWASP mapping
- A03:2021 Injection (XSS via javascript: protocol)
- A01:2021 Broken Access Control (open redirect)

## Known follow-up items (from code review)
- `window.open` at business-detail:363 for Google Maps — missing explicit `noopener,noreferrer` 3rd arg (modern browsers default to it, but explicit is better)
- IDN/homograph attack not addressed (backlog)
- Edge case tests: null byte, percent-encoded scheme, URL length cap

## Test plan
- [x] 21/21 unit tests pass
- [x] tsc --noEmit clean
- [x] ESLint clean
- [x] 100% coverage on safe-url.ts