### PR TITLE
fix(security): warn on missing RATE_LIMIT_TRUSTED_PROXY_HOPS + docs (S1-04)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,21 @@ UPSTASH_REDIS_REST_URL=
 UPSTASH_REDIS_REST_TOKEN=
 RATE_LIMIT_KEY_PREFIX=rate-limit
 
-# Number of trusted proxy hops to account for when resolving client IP from
-# X-Forwarded-For (0 keeps the previous "rightmost IP" behavior).
-RATE_LIMIT_TRUSTED_PROXY_HOPS=0
+# =============================================================================
+# RATE LIMITING — PROXY TRUST
+# =============================================================================
+# Number of trusted proxy hops between the public internet and this Next.js app.
+# This is CRITICAL for correct IP identification when behind load balancers.
+#
+# Common values:
+#   0 — Direct internet exposure (no proxy). DEFAULT but insecure for most deployments.
+#   1 — Single proxy (Vercel, Cloud Run, Nginx, single LB). RECOMMENDED for most setups.
+#   2 — Two proxies (e.g., CDN + LB).
+#
+# Without this set correctly, attackers can inject X-Forwarded-For headers to bypass
+# rate limits. Audit your deployment topology and set this explicitly in production.
+RATE_LIMIT_TRUSTED_PROXY_HOPS=1
+
+# Alternative: trust x-real-ip header instead of XFF (true/false).
+# Use only if your reverse proxy sets this header with the real client IP.
+# RATE_LIMIT_TRUST_X_REAL_IP=false

--- a/README.md
+++ b/README.md
@@ -116,12 +116,12 @@ NEXTAUTH_URL=http://localhost:3000
 NEXT_PUBLIC_API_URL=http://localhost:5001/api/v1
 ```
 
-> **Seguridad — Rate limiter detrás de proxies:** Si el servidor está detrás de un
-> proxy (Vercel, Cloud Run, Nginx, un LB), debes configurar
+> **Seguridad — Rate limiter detrás de proxies:** Si el servidor está detrás de
+> un proxy (Vercel, Cloud Run, Nginx, un LB), debes configurar
 > `RATE_LIMIT_TRUSTED_PROXY_HOPS` con el número de saltos de proxy confiables
 > (normalmente `1`). Sin esto, un atacante puede manipular la cabecera
-> `X-Forwarded-For` para evadir los límites de tasa. Consulta `.env.example` para
-> detalles y valores comunes.
+> `X-Forwarded-For` para evadir los límites de tasa. Consulta `.env.example`
+> para detalles y valores comunes.
 
 4. **Ejecutar en desarrollo**
 

--- a/README.md
+++ b/README.md
@@ -116,6 +116,13 @@ NEXTAUTH_URL=http://localhost:3000
 NEXT_PUBLIC_API_URL=http://localhost:5001/api/v1
 ```
 
+> **Seguridad — Rate limiter detrás de proxies:** Si el servidor está detrás de un
+> proxy (Vercel, Cloud Run, Nginx, un LB), debes configurar
+> `RATE_LIMIT_TRUSTED_PROXY_HOPS` con el número de saltos de proxy confiables
+> (normalmente `1`). Sin esto, un atacante puede manipular la cabecera
+> `X-Forwarded-For` para evadir los límites de tasa. Consulta `.env.example` para
+> detalles y valores comunes.
+
 4. **Ejecutar en desarrollo**
 
 ```bash

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -1,6 +1,21 @@
 // Rate limiting utility for API routes
 import { NextRequest, NextResponse } from "next/server";
 
+let proxyHopsWarningEmitted = false;
+
+function warnIfProxyHopsNotConfigured(): void {
+  if (proxyHopsWarningEmitted) return;
+  if (process.env.NODE_ENV !== "production") return;
+  if (process.env.RATE_LIMIT_TRUSTED_PROXY_HOPS === undefined) {
+    console.warn(
+      "[RATE-LIMIT] RATE_LIMIT_TRUSTED_PROXY_HOPS is not set in production. " +
+        "Defaulting to 0 may allow IP spoofing via X-Forwarded-For if the app runs behind one or more proxies. " +
+        "Set this to the number of trusted proxy hops (e.g., 1 for Vercel, Cloud Run, or Nginx)."
+    );
+    proxyHopsWarningEmitted = true;
+  }
+}
+
 interface RateLimitOptions {
   windowMs: number; // Time window in milliseconds
   maxAttempts: number; // Maximum attempts per window
@@ -190,6 +205,8 @@ function isValidIP(ip: string): boolean {
 
 // Utility to get client IP
 function getClientIP(request: NextRequest): string {
+  warnIfProxyHopsNotConfigured();
+
   // Only trust x-real-ip when explicitly enabled via env var. Without this
   // guard an attacker can forge the header and bypass per-IP rate limits.
   if (process.env.RATE_LIMIT_TRUST_X_REAL_IP === "true") {


### PR DESCRIPTION
## Summary
- Warn once at runtime in production if `RATE_LIMIT_TRUSTED_PROXY_HOPS` is undefined
- Expand `.env.example` with clear documentation of common values (0/1/2) and threat model
- Add security callout in README.md under env vars section
- No logic change in IP identification — pure observability + docs

## Audit reference
SEC-07 — Rate limit in-memory / IP spoofing via X-Forwarded-For when proxy hops not configured. Deployment-dependent vulnerability.

## Test plan
- [x] Warning guard ensures single emission per process
- [x] tsc --noEmit clean
- [ ] Manual verification: deploy to staging without the var and observe single warning in logs